### PR TITLE
Restoring github, instagram, and facebook links

### DIFF
--- a/_includes/contact-list.html
+++ b/_includes/contact-list.html
@@ -12,6 +12,12 @@
     <li>{% include icon-github.html username=site.github_username label='GitHub' %}</li>
   {% endif %}
 
+  <li>{% include icon-instagram.html username='make_roanoke' label='Instagram' styles=dark_icon %}</li>
+
+  <li>{% include icon-facebook.html username='profile.php?id=61555003782595' label='Facebook' styles="dark_icon" %}</li>
+
+  <li>{% include icon-discord.html username='eWY2pFUE2n' label='Discord' styles="dark_icon" %}</li>
+
   {% if site.twitter_username %}
     <li>{% include icon-twitter.html username=site.twitter_username label='Twitter' %}</li>
   {% endif %}


### PR DESCRIPTION
This restores the discord, instagram, and facebook links that were removed as part of https://github.com/MAKEroanoke/makeroanoke.org/commit/bf638d43cead30c54aabd115d3318a356d036c90#diff-e6801223aafc53cf3b93ef9811955626cab9785d485c39b9ef69ace3a07b67a7L17